### PR TITLE
Set npm dependency update team as Renovate and npm audit reviewer

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["github>js-soft/renovate-config"],
-    "reviewers": ["Milena-Czierlinski", "britsta"]
+    "reviewers": ["team:npm-dependency-update-reviewers"]
 }

--- a/.github/workflows/dependency-security-maintenance.yml
+++ b/.github/workflows/dependency-security-maintenance.yml
@@ -10,5 +10,7 @@ permissions: {}
 jobs:
   npm-audit:
     uses: js-soft/github-actions/.github/workflows/dependency-security-maintenance.yml@main
+    with:
+      reviewers: js-soft/npm-dependency-update-reviewers
     secrets:
       github-token: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This PR routes Renovate and npm audit pull requests to the npm dependency update reviewers team.

Changes:
- replace existing Renovate reviewers with team:npm-dependency-update-reviewers where this repository has a root package-lock.json and Renovate config
- pass js-soft/npm-dependency-update-reviewers to the dependency security maintenance workflow

Validation:
- parsed Renovate JSON with jq
- parsed workflow YAML with Ruby
- checked touched files with Prettier